### PR TITLE
ENH Archiver Time Plot insert live data

### DIFF
--- a/examples/archiver_time_plot/archiver_time_plot_example.py
+++ b/examples/archiver_time_plot/archiver_time_plot_example.py
@@ -1,7 +1,7 @@
 from pydm import Display
 
 from qtpy import QtCore
-from qtpy.QtWidgets import QHBoxLayout, QApplication
+from qtpy.QtWidgets import QHBoxLayout, QApplication, QCheckBox
 from pydm.widgets import PyDMArchiverTimePlot
 
 
@@ -22,11 +22,17 @@ class archiver_time_plot_example(Display):
         self.setLayout(self.main_layout)
         self.plot_live = PyDMArchiverTimePlot(background=[255, 255, 255, 255])
         self.plot_archived = PyDMArchiverTimePlot(background=[255, 255, 255, 255])
+        self.chkbx_live = QCheckBox()
+        self.chkbx_live.setChecked(True)
+        self.chkbx_archived = QCheckBox()
+        self.chkbx_archived.setChecked(True)
+        self.main_layout.addWidget(self.chkbx_live)
         self.main_layout.addWidget(self.plot_live)
         self.main_layout.addWidget(self.plot_archived)
+        self.main_layout.addWidget(self.chkbx_archived)
 
-        self.plot_live.addYChannel(
-            y_channel="CA://XCOR:LI29:302:IACT",
+        curve_live = self.plot_live.addYChannel(
+            y_channel="ca://XCOR:LI29:302:IACT",
             name="name",
             color="red",
             yAxisName="Axis",
@@ -34,11 +40,18 @@ class archiver_time_plot_example(Display):
             liveData=True,
         )
 
-        self.plot_archived.addYChannel(
-            y_channel="CA://XCOR:LI29:302:IACT",
+        curve_archived = self.plot_archived.addYChannel(
+            y_channel="ca://XCOR:LI28:302:IACT",
             name="name",
             color="blue",
             yAxisName="Axis",
             useArchiveData=True,
             liveData=False,
         )
+
+        self.chkbx_live.stateChanged.connect(lambda x: self.set_live(curve_live, x))
+        self.chkbx_archived.stateChanged.connect(lambda x: self.set_live(curve_archived, x))
+
+    @staticmethod
+    def set_live(curve, live):
+        curve.liveData = live


### PR DESCRIPTION
These changes are for the scenario when a user disables live data gathering on an Archive Curve and reenables live data gathering. Once live data gathering resumes, this code will fill the curve's live data buffer with data gathered from the archiver appliance during the missed period.

1. A new property (liveData) is added to the ArchivePlotCurveItem. The setter makes a call to the archiver appliance. When the data is received, if the timestamps are more recent than the archived data, then the data is inserted into the live data buffer (using the new function below).
 
2. A new function (insert_live_data) is added to TimePlotCurveItem to insert a 2-D array of data into the curve's live data buffer. This function mimics an existing function for the ArchivePlotCurveItem (insert_archive_data).

3. The archiver_time_plot_example file has been updated to allow the tester to enable/disable live data gathering.