### PR TITLE
Rename BasePlot.curves() to getCurveItems() to avoid Qt Property shad…

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -101,6 +101,24 @@ def test_baseplot_add_curve(qtbot):
     qtbot.addWidget(base_plot)
 
 
+def test_getCurveItems_not_shadowed(qtbot):
+    """Verify getCurveItems returns actual curve objects, not the JSON
+    strings produced by the Qt Property ``curves`` on subclasses."""
+    waveform_plot = PyDMWaveformPlot()
+    qtbot.addWidget(waveform_plot)
+
+    curve = WaveformCurveItem()
+    waveform_plot.addCurve(curve)
+
+    items = waveform_plot.getCurveItems()
+    assert len(items) == 1
+    assert items[0] is curve
+
+    json_curves = waveform_plot.curves
+    assert len(json_curves) == 1
+    assert isinstance(json_curves[0], str)
+
+
 def test_baseplot_multiple_y_axes(qtbot):
     """Test that when we add curves while specifying new y-axis names for them, those axes are created and
     added to the plot correctly. Also confirm that adding a curve to an existing axis works properly."""

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -1005,7 +1005,13 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
     def curveAtIndex(self, index: int) -> BasePlotCurveItem:
         return self._curves[index]
 
-    def curves(self) -> List[BasePlotCurveItem]:
+    def getCurveItems(self) -> List[BasePlotCurveItem]:
+        """Return the list of curve items on this plot.
+
+        This method is named getCurveItems to avoid being shadowed by
+        the ``curves`` Qt Property on subclasses, which serializes curve
+        data as JSON strings for .ui files.
+        """
         return self._curves
 
     def clear(self) -> None:


### PR DESCRIPTION
## Description 
Rename BasePlot.curves() to getCurveItems() so subclass Qt Properties named curves no longer shadow the base method
Adds test verifying both getCurveItems() and the curves Property work correctly

Fixes #687