### PR TITLE
Consume middle mouse button release in event filter

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -284,6 +284,34 @@ def test_middle_click(qtbot, monkeypatch, widget_class, init_channel, expected_c
     assert copied_text == expected_clipboard_text
 
 
+def test_middle_click_release_consumed(qtbot, monkeypatch):
+    """Verify that middle button release is consumed by the event filter so
+    that widgets like QLineEdit do not paste from the selection clipboard."""
+    from qtpy.QtCore import QEvent
+
+    widget = PyDMLineEdit(init_channel="CA://TEST_PV")
+    qtbot.addWidget(widget)
+    qtbot.waitExposed(widget)
+
+    # Mock clipboard so we don't modify the real one
+    monkeypatch.setattr(QClipboard, "setText", lambda *a, **kw: None)
+
+    # Simulate middle press (consumed by event filter)
+    press_event = QMouseEvent(
+        QEvent.MouseButtonPress, widget.rect().center(), Qt.MiddleButton, Qt.MiddleButton, Qt.NoModifier
+    )
+    assert widget.eventFilter(widget, press_event) is True
+
+    # Simulate middle release — should also be consumed
+    release_event = QMouseEvent(
+        QEvent.MouseButtonRelease, widget.rect().center(), Qt.MiddleButton, Qt.MiddleButton, Qt.NoModifier
+    )
+    assert widget.eventFilter(widget, release_event) is True
+
+    # Verify nothing was pasted into the line edit
+    assert widget.text() == ""
+
+
 @pytest.mark.parametrize(
     "init_channel",
     [

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -293,22 +293,18 @@ def test_middle_click_release_consumed(qtbot, monkeypatch):
     qtbot.addWidget(widget)
     qtbot.waitExposed(widget)
 
-    # Mock clipboard so we don't modify the real one
     monkeypatch.setattr(QClipboard, "setText", lambda *a, **kw: None)
 
-    # Simulate middle press (consumed by event filter)
     press_event = QMouseEvent(
         QEvent.MouseButtonPress, widget.rect().center(), Qt.MiddleButton, Qt.MiddleButton, Qt.NoModifier
     )
     assert widget.eventFilter(widget, press_event) is True
 
-    # Simulate middle release — should also be consumed
     release_event = QMouseEvent(
         QEvent.MouseButtonRelease, widget.rect().center(), Qt.MiddleButton, Qt.MiddleButton, Qt.NoModifier
     )
     assert widget.eventFilter(widget, release_event) is True
 
-    # Verify nothing was pasted into the line edit
     assert widget.text() == ""
 
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -199,11 +199,12 @@ class PyDMPrimitiveWidget(object):
         return QIcon()
 
     def eventFilter(self, obj, event):
+        """Consume middle mouse button press and release events.
+
+        On press, shows the PV address tooltip and copies the address to
+        the clipboard.  The release is also consumed to prevent widgets
+        like QLineEdit from pasting from the X11 selection clipboard.
         """
-        EventFilter to redirect "middle click" to :meth:`.show_address_tooltip`
-        """
-        # Override the eventFilter to capture all middle mouse button events,
-        # and show a tooltip if needed.
         if event.type() in (QEvent.MouseButtonPress, QEvent.MouseButtonRelease):
             if event.button() == Qt.MiddleButton:
                 if event.type() == QEvent.MouseButtonPress:

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -204,9 +204,10 @@ class PyDMPrimitiveWidget(object):
         """
         # Override the eventFilter to capture all middle mouse button events,
         # and show a tooltip if needed.
-        if event.type() == QEvent.MouseButtonPress:
+        if event.type() in (QEvent.MouseButtonPress, QEvent.MouseButtonRelease):
             if event.button() == Qt.MiddleButton:
-                self.show_address_tooltip(event)
+                if event.type() == QEvent.MouseButtonPress:
+                    self.show_address_tooltip(event)
                 return True
         return False
 


### PR DESCRIPTION
The event filter already consumed the middle button press (to show the PV address tooltip), but the release passed through to the widget. On X11 this caused QLineEdit to paste from the selection clipboard.

Fixes #1030