### PR TITLE
Handle list-type macros in Designer Basic Settings Editor

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/tests/widgets/test_designer_settings.py
+++ b/pydm/tests/widgets/test_designer_settings.py
@@ -11,7 +11,19 @@ class FakeWidget:
 
 
 def _make_table(qtbot, macros_value):
-    """Create a PropertyMacroTable backed by a FakeWidget."""
+    """Create a PropertyMacroTable backed by a FakeWidget.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt fixture for widget management.
+    macros_value : str, list of str, or None
+        The macro value to initialize the table with.
+
+    Returns
+    -------
+    PropertyMacroTable
+    """
     widget = FakeWidget(macros=macros_value)
     table = PropertyMacroTable(property_widget=widget, property_name="macros")
     qtbot.addWidget(table)

--- a/pydm/tests/widgets/test_designer_settings.py
+++ b/pydm/tests/widgets/test_designer_settings.py
@@ -1,0 +1,54 @@
+import pytest
+
+from pydm.widgets.designer_settings import PropertyMacroTable
+
+
+class FakeWidget:
+    """Minimal mock with a macros attribute for PropertyMacroTable tests."""
+
+    def __init__(self, macros):
+        self.macros = macros
+
+
+def _make_table(qtbot, macros_value):
+    """Create a PropertyMacroTable backed by a FakeWidget."""
+    widget = FakeWidget(macros=macros_value)
+    table = PropertyMacroTable(property_widget=widget, property_name="macros")
+    qtbot.addWidget(table)
+    return table
+
+
+def test_macro_table_single_string(qtbot):
+    """PropertyMacroTable handles a single JSON string (PyDMEmbeddedDisplay)."""
+    table = _make_table(qtbot, '{"top": "FooBar"}')
+    assert table.dictionary == {"top": "FooBar"}
+
+
+def test_macro_table_list_single_element(qtbot):
+    """PropertyMacroTable handles a list with one JSON string (PyDMRelatedDisplayButton)."""
+    table = _make_table(qtbot, ['{"top": "FooBar"}'])
+    assert table.dictionary == {"top": "FooBar"}
+
+
+def test_macro_table_list_multiple_elements(qtbot):
+    """PropertyMacroTable merges multiple macro sets from a list."""
+    table = _make_table(qtbot, ['{"a": "1"}', '{"b": "2"}'])
+    assert table.dictionary == {"a": "1", "b": "2"}
+
+
+def test_macro_table_list_with_empty_string(qtbot):
+    """PropertyMacroTable handles lists that include empty strings."""
+    table = _make_table(qtbot, ['{"top": "FooBar"}', ""])
+    assert table.dictionary == {"top": "FooBar"}
+
+
+def test_macro_table_empty_string(qtbot):
+    """PropertyMacroTable handles an empty string gracefully."""
+    table = _make_table(qtbot, "")
+    assert table.dictionary == {}
+
+
+def test_macro_table_none(qtbot):
+    """PropertyMacroTable handles None gracefully."""
+    table = _make_table(qtbot, None)
+    assert table.dictionary == {}

--- a/pydm/widgets/designer_settings.py
+++ b/pydm/widgets/designer_settings.py
@@ -264,7 +264,13 @@ class PropertyIntSpinBox(_PropertyHelper, QtWidgets.QSpinBox):
 class PropertyMacroTable(_PropertyHelper, DictionaryTable):
     def set_value_from_widget(self, widget, attr, value):
         try:
-            macros = parse_macro_string(value or "")
+            # PyDMRelatedDisplayButton stores macros as a list of JSON
+            # strings (one per display file), while PyDMEmbeddedDisplay
+            # uses a single string. Normalize to a list and merge.
+            items = value if isinstance(value, list) else [value]
+            macros = {}
+            for item in items:
+                macros.update(parse_macro_string(item or ""))
         except Exception:
             logger.exception("Failed to parse macro string: %r", value)
         else:

--- a/pydm/widgets/designer_settings.py
+++ b/pydm/widgets/designer_settings.py
@@ -263,10 +263,22 @@ class PropertyIntSpinBox(_PropertyHelper, QtWidgets.QSpinBox):
 
 class PropertyMacroTable(_PropertyHelper, DictionaryTable):
     def set_value_from_widget(self, widget, attr, value):
+        """Parse macro value from the widget property into the table dictionary.
+
+        Handles both single JSON strings (``PyDMEmbeddedDisplay``) and lists
+        of JSON strings (``PyDMRelatedDisplayButton``, one per display file)
+        by normalizing to a list and merging all entries.
+
+        Parameters
+        ----------
+        widget : QWidget
+            The widget whose property is being read.
+        attr : str
+            The property name.
+        value : str or list of str
+            Macro value(s) from the widget property.
+        """
         try:
-            # PyDMRelatedDisplayButton stores macros as a list of JSON
-            # strings (one per display file), while PyDMEmbeddedDisplay
-            # uses a single string. Normalize to a list and merge.
             items = value if isinstance(value, list) else [value]
             macros = {}
             for item in items:


### PR DESCRIPTION
PropertyMacroTable now normalizes list inputs (from PyDMRelatedDisplayButton) by merging per-display macro dicts into one for editing.

Fixes #973