### PR TITLE
Snap line drawings to pixel grid for crisp rendering

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -508,11 +508,18 @@ class PyDMDrawingLineBase(PyDMDrawing):
         self._arrow_mid_point_flipped = False
 
     def draw_item(self, painter):
+        """Set up the painter and apply a half-pixel offset for crisp lines.
+
+        With antialiasing enabled, odd-width lines straddle pixel boundaries
+        causing sub-pixel blending.  A half-pixel shift aligns line centers
+        to the pixel grid.
+
+        Parameters
+        ----------
+        painter : QPainter
+            The painter used to draw the line.
+        """
         super().draw_item(painter)
-        # With antialiasing, lines are drawn centered on coordinates. When
-        # the pen width is odd this straddles pixel boundaries, causing
-        # sub-pixel blending that looks blurry. Shifting by half a pixel
-        # aligns line centers to the pixel grid.
         if self._pen.width() % 2 == 1:
             painter.translate(0.5, 0.5)
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -507,6 +507,15 @@ class PyDMDrawingLineBase(PyDMDrawing):
         self._arrow_mid_point_selection = False
         self._arrow_mid_point_flipped = False
 
+    def draw_item(self, painter):
+        super().draw_item(painter)
+        # With antialiasing, lines are drawn centered on coordinates. When
+        # the pen width is odd this straddles pixel boundaries, causing
+        # sub-pixel blending that looks blurry. Shifting by half a pixel
+        # aligns line centers to the pixel grid.
+        if self._pen.width() % 2 == 1:
+            painter.translate(0.5, 0.5)
+
     def readArrowSize(self) -> int:
         """
         Size to render line arrows.


### PR DESCRIPTION
Add half-pixel offset in PyDMDrawingLineBase when pen width is odd, aligning line centers to pixel boundaries under antialiasing.

Fixes #1089