### PR TITLE
Default disconnectWhenHidden to False on PyDMEmbeddedDisplay

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -49,7 +49,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         self._recursive_display_search = False
         self._macros = None
         self._embedded_widget = None
-        self._disconnect_when_hidden = True
+        self._disconnect_when_hidden = False
         self._is_connected = False
         self._only_load_when_shown = True
         self._needs_load = True


### PR DESCRIPTION
Avoids connect/disconnect storms during screen creation when many embedded displays fire show/hide events from Qt layout operations.

Fixes #646