### PR TITLE
Support QMainWindow .ui files in load_ui_file

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -14,7 +14,9 @@ from typing import Dict, Optional, Tuple
 
 import re
 import six
-from qtpy.QtWidgets import QApplication, QWidget
+import xml.etree.ElementTree as ET
+
+from qtpy.QtWidgets import QApplication, QMainWindow, QWidget
 
 from .help_files import HelpWindow
 from .utilities import import_module_by_filename, is_pydm_app, macro, ACTIVE_QT_WRAPPER, QtWrapperTypes
@@ -186,6 +188,26 @@ def _load_compiled_ui_into_display(
     display.ui = display
 
 
+def _get_ui_root_widget_class(uifile):
+    """Return the class name of the root widget defined in a .ui file.
+
+    Parameters
+    ----------
+    uifile : str
+        Path to the .ui file.
+
+    Returns
+    -------
+    str
+        The root widget class name (e.g. ``"QWidget"``, ``"QMainWindow"``).
+    """
+    tree = ET.parse(uifile)
+    widget_elem = tree.getroot().find("widget")
+    if widget_elem is not None:
+        return widget_elem.get("class", "QWidget")
+    return "QWidget"
+
+
 def load_ui_file(uifile, macros=None, args=None):
     """
     Load a .ui file, perform macro substitution, then return the resulting QWidget.
@@ -207,7 +229,11 @@ def load_ui_file(uifile, macros=None, args=None):
     QWidget
     """
 
-    display = Display(macros=macros)
+    root_class = _get_ui_root_widget_class(uifile)
+    if root_class == "QMainWindow":
+        display = MainWindowDisplay(macros=macros)
+    else:
+        display = Display(macros=macros)
     display.load_ui_from_file(uifile, macros)
     return display
 
@@ -483,3 +509,67 @@ class Display(QWidget):
                 self._local_style = f.read()
         logger.debug("Setting stylesheet to: %s", self._local_style)
         super().setStyleSheet(self._local_style)
+
+
+class MainWindowDisplay(QMainWindow):
+    """Display subclass backed by QMainWindow for .ui files that use QMainWindow
+    as their root widget.
+
+    Provides the same interface as :class:`Display` so the rest of pydm can
+    treat it interchangeably.
+
+    Parameters
+    ----------
+    parent : QWidget, optional
+        The parent widget.
+    macros : dict, optional
+        Macro substitutions for the display.
+    """
+
+    def __init__(self, parent=None, macros=None):
+        super().__init__(parent)
+        self.ui = None
+        self.help_window = None
+        self._loaded_file = None
+        self._macros = macros
+        self._previous_display = None
+        self._next_display = None
+        self._local_style = ""
+
+    def loaded_file(self):
+        return self._loaded_file
+
+    @property
+    def previous_display(self):
+        return self._previous_display
+
+    @previous_display.setter
+    def previous_display(self, display):
+        self._previous_display = display
+
+    @property
+    def next_display(self):
+        return self._next_display
+
+    @next_display.setter
+    def next_display(self, display):
+        self._next_display = display
+
+    def macros(self):
+        if self._macros is None:
+            return {}
+        return self._macros
+
+    def load_ui_from_file(self, ui_file_path, macros=None):
+        """Load the .ui file and populate this window.
+
+        Parameters
+        ----------
+        ui_file_path : str
+            Path to the .ui file.
+        macros : dict, optional
+            Macro substitutions.
+        """
+        self._loaded_file = ui_file_path
+        code_string, class_name = _compile_ui_file(ui_file_path)
+        _load_compiled_ui_into_display(code_string, class_name, self, macros)

--- a/pydm/tests/test_data/mainwindow_test.ui
+++ b/pydm/tests/test_data/mainwindow_test.ui
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QLabel" name="label">
+    <property name="text">
+     <string>Test Label</string>
+    </property>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/test_mainwindow_display.py
+++ b/pydm/tests/test_mainwindow_display.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+from pydm.display import Display, MainWindowDisplay, load_ui_file, _get_ui_root_widget_class
+from qtpy.QtWidgets import QMainWindow, QWidget
+
+TEST_DATA = os.path.join(os.path.dirname(__file__), "test_data")
+MAINWINDOW_UI = os.path.join(TEST_DATA, "mainwindow_test.ui")
+
+
+def test_get_ui_root_widget_class_mainwindow():
+    """Detect QMainWindow as root widget class in a .ui file."""
+    assert _get_ui_root_widget_class(MAINWINDOW_UI) == "QMainWindow"
+
+
+def test_load_mainwindow_ui_returns_mainwindow_display(qtbot):
+    """Loading a QMainWindow .ui file produces a MainWindowDisplay instance.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt fixture for widget management.
+    """
+    display = load_ui_file(MAINWINDOW_UI)
+    qtbot.addWidget(display)
+    assert isinstance(display, MainWindowDisplay)
+    assert isinstance(display, QMainWindow)
+
+
+def test_load_mainwindow_ui_does_not_crash(qtbot):
+    """QMainWindow .ui files should load without AttributeError.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt fixture for widget management.
+    """
+    display = load_ui_file(MAINWINDOW_UI)
+    qtbot.addWidget(display)
+    assert hasattr(display, "setCentralWidget")
+    assert display.centralWidget() is not None


### PR DESCRIPTION
Detect root widget class from .ui XML and use MainWindowDisplay (QMainWindow-based) when the file defines a QMainWindow, avoiding the AttributeError on setCentralWidget.

Fixes 1321