### PR TITLE
Support QMainWindow .ui files with DisplayBase mixin

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -14,7 +14,9 @@ from typing import Dict, Optional, Tuple
 
 import re
 import six
-from qtpy.QtWidgets import QApplication, QWidget
+import xml.etree.ElementTree as ET
+
+from qtpy.QtWidgets import QApplication, QMainWindow, QWidget
 
 from .help_files import HelpWindow
 from .utilities import import_module_by_filename, is_pydm_app, macro, ACTIVE_QT_WRAPPER, QtWrapperTypes
@@ -186,6 +188,26 @@ def _load_compiled_ui_into_display(
     display.ui = display
 
 
+def _get_ui_root_widget_class(uifile):
+    """Return the class name of the root widget defined in a .ui file.
+
+    Parameters
+    ----------
+    uifile : str
+        Path to the .ui file.
+
+    Returns
+    -------
+    str
+        The root widget class name (e.g. ``"QWidget"``, ``"QMainWindow"``).
+    """
+    tree = ET.parse(uifile)
+    widget_elem = tree.getroot().find("widget")
+    if widget_elem is not None:
+        return widget_elem.get("class", "QWidget")
+    return "QWidget"
+
+
 def load_ui_file(uifile, macros=None, args=None):
     """
     Load a .ui file, perform macro substitution, then return the resulting QWidget.
@@ -207,7 +229,11 @@ def load_ui_file(uifile, macros=None, args=None):
     QWidget
     """
 
-    display = Display(macros=macros)
+    root_class = _get_ui_root_widget_class(uifile)
+    if root_class == "QMainWindow":
+        display = MainWindowDisplay(macros=macros)
+    else:
+        display = Display(macros=macros)
     display.load_ui_from_file(uifile, macros)
     return display
 
@@ -483,3 +509,67 @@ class Display(QWidget):
                 self._local_style = f.read()
         logger.debug("Setting stylesheet to: %s", self._local_style)
         super().setStyleSheet(self._local_style)
+
+
+class MainWindowDisplay(QMainWindow):
+    """Display subclass backed by QMainWindow for .ui files that use QMainWindow
+    as their root widget.
+
+    Provides the same interface as :class:`Display` so the rest of pydm can
+    treat it interchangeably.
+
+    Parameters
+    ----------
+    parent : QWidget, optional
+        The parent widget.
+    macros : dict, optional
+        Macro substitutions for the display.
+    """
+
+    def __init__(self, parent=None, macros=None):
+        super().__init__(parent)
+        self.ui = None
+        self.help_window = None
+        self._loaded_file = None
+        self._macros = macros
+        self._previous_display = None
+        self._next_display = None
+        self._local_style = ""
+
+    def loaded_file(self):
+        return self._loaded_file
+
+    @property
+    def previous_display(self):
+        return self._previous_display
+
+    @previous_display.setter
+    def previous_display(self, display):
+        self._previous_display = display
+
+    @property
+    def next_display(self):
+        return self._next_display
+
+    @next_display.setter
+    def next_display(self, display):
+        self._next_display = display
+
+    def macros(self):
+        if self._macros is None:
+            return {}
+        return self._macros
+
+    def load_ui_from_file(self, ui_file_path, macros=None):
+        """Load the .ui file and populate this window.
+
+        Parameters
+        ----------
+        ui_file_path : str
+            Path to the .ui file.
+        macros : dict, optional
+            Macro substitutions.
+        """
+        self._loaded_file = ui_file_path
+        code_string, class_name = _compile_ui_file(ui_file_path)
+        _load_compiled_ui_into_display(code_string, class_name, self, macros)

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -355,9 +355,26 @@ _extension_to_loader = {
 }
 
 
-class Display(QWidget):
-    def __init__(self, parent=None, args=None, macros=None, ui_filename=None):
-        super().__init__(parent)
+class DisplayBase:
+    """Shared implementation for display-like widgets.
+
+    Provides navigation, macro handling, file loading, and stylesheet
+    support.  Mixed into both :class:`Display` (QWidget-based) and
+    :class:`MainWindowDisplay` (QMainWindow-based).
+    """
+
+    def _init_display(self, args=None, macros=None, ui_filename=None):
+        """Initialize display state.  Must be called from subclass ``__init__``.
+
+        Parameters
+        ----------
+        args : list, optional
+            Command-line arguments forwarded to the display.
+        macros : dict, optional
+            Macro substitutions.
+        ui_filename : str, optional
+            Filename of the .ui file to load.
+        """
         self.ui = None
         self.help_window = None
         self._ui_filename = ui_filename
@@ -367,8 +384,6 @@ class Display(QWidget):
         self._previous_display = None
         self._next_display = None
         self._local_style = ""
-        if ui_filename or self.ui_filename():
-            self.load_ui(macros=macros)
 
     def loaded_file(self):
         return self._loaded_file
@@ -511,12 +526,21 @@ class Display(QWidget):
         super().setStyleSheet(self._local_style)
 
 
-class MainWindowDisplay(QMainWindow):
-    """Display subclass backed by QMainWindow for .ui files that use QMainWindow
-    as their root widget.
+class Display(DisplayBase, QWidget):
+    def __init__(self, parent=None, args=None, macros=None, ui_filename=None):
+        super().__init__(parent)
+        self._init_display(args=args, macros=macros, ui_filename=ui_filename)
+        if ui_filename or self.ui_filename():
+            self.load_ui(macros=macros)
 
-    Provides the same interface as :class:`Display` so the rest of pydm can
-    treat it interchangeably.
+
+class MainWindowDisplay(DisplayBase, QMainWindow):
+    """Display backed by QMainWindow for .ui files that use QMainWindow as
+    their root widget.
+
+    Inherits the full display interface from :class:`DisplayBase` so it
+    passes ``isinstance(widget, Display)`` checks used throughout pydm for
+    navigation, menu items, macro propagation, and help support.
 
     Parameters
     ----------
@@ -528,48 +552,4 @@ class MainWindowDisplay(QMainWindow):
 
     def __init__(self, parent=None, macros=None):
         super().__init__(parent)
-        self.ui = None
-        self.help_window = None
-        self._loaded_file = None
-        self._macros = macros
-        self._previous_display = None
-        self._next_display = None
-        self._local_style = ""
-
-    def loaded_file(self):
-        return self._loaded_file
-
-    @property
-    def previous_display(self):
-        return self._previous_display
-
-    @previous_display.setter
-    def previous_display(self, display):
-        self._previous_display = display
-
-    @property
-    def next_display(self):
-        return self._next_display
-
-    @next_display.setter
-    def next_display(self, display):
-        self._next_display = display
-
-    def macros(self):
-        if self._macros is None:
-            return {}
-        return self._macros
-
-    def load_ui_from_file(self, ui_file_path, macros=None):
-        """Load the .ui file and populate this window.
-
-        Parameters
-        ----------
-        ui_file_path : str
-            Path to the .ui file.
-        macros : dict, optional
-            Macro substitutions.
-        """
-        self._loaded_file = ui_file_path
-        code_string, class_name = _compile_ui_file(ui_file_path)
-        _load_compiled_ui_into_display(code_string, class_name, self, macros)
+        self._init_display(macros=macros)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -11,7 +11,7 @@ from .utilities import (
     close_widget_connections,
 )
 from .pydm_ui import Ui_MainWindow
-from .display import Display, ScreenTarget, load_file, clear_compiled_ui_file_cache
+from .display import Display, DisplayBase, ScreenTarget, load_file, clear_compiled_ui_file_cache
 from .connection_inspector import ConnectionInspector
 from .about_pydm import AboutWindow
 from .show_macros import MacroWindow
@@ -255,7 +255,7 @@ class PyDMMainWindow(QMainWindow):
             self.ui.actionForward.setDisabled(True)
             return
 
-        if not isinstance(w, Display):
+        if not isinstance(w, DisplayBase):
             # We can't do much if it is not a Display and we don't have the
             # previous_display and next_display properties since we don't
             # have the navigation stack set.
@@ -327,7 +327,7 @@ class PyDMMainWindow(QMainWindow):
         if extension == ".ui":
             return self.current_file(), None
         else:
-            central_widget = self.centralWidget() if isinstance(self.centralWidget(), Display) else None
+            central_widget = self.centralWidget() if isinstance(self.centralWidget(), DisplayBase) else None
             if central_widget is not None:
                 ui_file = central_widget.ui_filepath()
             return ui_file, self.current_file()
@@ -571,7 +571,7 @@ class PyDMMainWindow(QMainWindow):
 
     def add_menu_items(self):
         # create the custom menu with user given items
-        if not isinstance(self.display_widget(), Display):
+        if not isinstance(self.display_widget(), DisplayBase):
             return
 
         # Only provide the view help menu option if an associated help file has been loaded

--- a/pydm/tests/test_data/mainwindow_test.ui
+++ b/pydm/tests/test_data/mainwindow_test.ui
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QLabel" name="label">
+    <property name="text">
+     <string>Test Label</string>
+    </property>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/test_mainwindow_display.py
+++ b/pydm/tests/test_mainwindow_display.py
@@ -39,3 +39,29 @@ def test_load_mainwindow_ui_does_not_crash(qtbot):
     qtbot.addWidget(display)
     assert hasattr(display, "setCentralWidget")
     assert display.centralWidget() is not None
+
+
+def test_mainwindow_display_has_full_display_interface(qtbot):
+    """MainWindowDisplay should have all Display methods so isinstance checks
+    and navigation/menu/macro features work correctly.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt fixture for widget management.
+    """
+    display = load_ui_file(MAINWINDOW_UI)
+    qtbot.addWidget(display)
+
+    assert hasattr(display, "args")
+    assert hasattr(display, "macros")
+    assert hasattr(display, "loaded_file")
+    assert hasattr(display, "menu_items")
+    assert hasattr(display, "file_menu_items")
+    assert hasattr(display, "show_help")
+    assert hasattr(display, "navigate_back")
+    assert hasattr(display, "navigate_forward")
+    assert hasattr(display, "load_ui_from_file")
+    assert hasattr(display, "load_help_file")
+    assert hasattr(display, "previous_display")
+    assert hasattr(display, "next_display")

--- a/pydm/tests/test_mainwindow_display.py
+++ b/pydm/tests/test_mainwindow_display.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+from pydm.display import Display, MainWindowDisplay, load_ui_file, _get_ui_root_widget_class
+from qtpy.QtWidgets import QMainWindow, QWidget
+
+TEST_DATA = os.path.join(os.path.dirname(__file__), "test_data")
+MAINWINDOW_UI = os.path.join(TEST_DATA, "mainwindow_test.ui")
+
+
+def test_get_ui_root_widget_class_mainwindow():
+    """Detect QMainWindow as root widget class in a .ui file."""
+    assert _get_ui_root_widget_class(MAINWINDOW_UI) == "QMainWindow"
+
+
+def test_load_mainwindow_ui_returns_mainwindow_display(qtbot):
+    """Loading a QMainWindow .ui file produces a MainWindowDisplay instance.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt fixture for widget management.
+    """
+    display = load_ui_file(MAINWINDOW_UI)
+    qtbot.addWidget(display)
+    assert isinstance(display, MainWindowDisplay)
+    assert isinstance(display, QMainWindow)
+
+
+def test_load_mainwindow_ui_does_not_crash(qtbot):
+    """QMainWindow .ui files should load without AttributeError.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt fixture for widget management.
+    """
+    display = load_ui_file(MAINWINDOW_UI)
+    qtbot.addWidget(display)
+    assert hasattr(display, "setCentralWidget")
+    assert display.centralWidget() is not None

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -14,7 +14,7 @@ from qtpy.QtCore import Qt, QEvent, Signal, Slot
 from .channel import PyDMChannel
 from pydm import data_plugins, tools, config
 from pydm.utilities import is_qt_designer, remove_protocol
-from pydm.display import Display
+from pydm.display import Display, DisplayBase
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -368,7 +368,7 @@ class PyDMPrimitiveWidget(object):
     def find_parent_display(self):
         widget = self.parent()
         while widget is not None:
-            if isinstance(widget, Display):
+            if isinstance(widget, DisplayBase):
                 return widget
             widget = widget.parent()
         return None


### PR DESCRIPTION
## Summary
- Detect QMainWindow root widget in .ui files and use MainWindowDisplay
- Extract shared Display interface into DisplayBase mixin
- Update isinstance checks to use DisplayBase

Fixes 1321