### PR TITLE
Reset EnumButton visual state after click to match PV value

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/tests/widgets/test_enum_button.py
+++ b/pydm/tests/widgets/test_enum_button.py
@@ -258,7 +258,10 @@ def test_send_receive_value(qtbot, signals):
     signals.new_value_signal[int].emit(1)
     assert widget.value == 1
     assert widget._widgets[1].isChecked()
+
     widget._widgets[2].click()
+    assert signals.value == 2
+
+    signals.new_value_signal[int].emit(2)
     assert not widget._widgets[1].isChecked()
     assert widget._widgets[2].isChecked()
-    assert signals.value == 2

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -406,16 +406,25 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
 
     @Slot(QAbstractButton)
     def handle_button_clicked(self, button):
-        """
-        Handles the event of a button being clicked.
+        """Handle a button click by sending the value and resetting visual state.
+
+        The visual state is immediately restored to the current PV value so
+        that rejected writes (e.g. PV disabled or in closed-loop mode) do not
+        leave the widget showing an incorrect selection.  If the write is
+        accepted, ``value_changed`` will update the visual state to the new
+        value.
 
         Parameters
         ----------
-        id : QAbstractButton
-            The clicked button button.
+        button : QAbstractButton
+            The clicked button.
         """
-        button_id = self._btn_group.id(button)  # get id of the button in the group
+        button_id = self._btn_group.id(button)
         self.send_value_signal.emit(button_id)
+        if self.value is not None and self.value != button_id:
+            current_btn = self._btn_group.button(self.value)
+            if current_btn:
+                current_btn.setChecked(True)
 
     def clear(self):
         """


### PR DESCRIPTION
## Summary
- Reset button group to current PV value after emitting send_value_signal
- If PV rejects write (disabled/closed-loop), widget shows correct state
- Updated test to verify full PV round-trip

Fixes #710