### PR TITLE
Override setLabels on MultiAxisPlot for arbitrary axis names

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -623,6 +623,27 @@ class MultiAxisPlot(PlotItem):
         self.enableAutoRange()
         self.recomputeAverages()
 
+    def setLabels(self, **kwargs):
+        """Set axis labels, silently skipping any axis not present on this plot.
+
+        Overrides the base ``PlotItem.setLabels`` which raises ``KeyError``
+        when an axis name is not found.  With multi-axis plots the default
+        four axes may have been replaced by user-defined names.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Mapping of axis name to label text.  The special key ``title``
+            sets the plot title.
+        """
+        for name, label in kwargs.items():
+            if name == "title":
+                self.setTitle(label)
+            elif name in self.axes:
+                if isinstance(label, str):
+                    label = (label,)
+                self.getAxis(name).setLabel(*label)
+
     def getViewBoxForAxis(self, axisName: str) -> ViewBox:
         """
         Retrieve the ViewBox associated with a given axis name.


### PR DESCRIPTION
## Summary
- Override setLabels to skip missing axes instead of raising KeyError
- Multi-axis plots may replace default axis names with custom ones

Fixes #901