### PR TITLE
Add rules support to PyDMTabWidget with Current Tab property

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -1,7 +1,7 @@
 from qtpy.QtWidgets import QTabBar, QTabWidget
 from qtpy.QtGui import QIcon, QColor
 from qtpy.QtCore import QByteArray
-from .base import PyDMWidget, PostParentClassInitSetup
+from .base import PyDMPrimitiveWidget, PyDMWidget, PostParentClassInitSetup
 from .channel import PyDMChannel
 from functools import partial
 from pydm.utilities.iconfont import IconFont
@@ -186,11 +186,14 @@ class PyDMTabBar(QTabBar, PyDMWidget):
             self.set_initial_icon_for_tab(i)
 
 
-class PyDMTabWidget(QTabWidget):
+class PyDMTabWidget(QTabWidget, PyDMPrimitiveWidget):
     """PyDMTabWidget provides a tabbed container widget.  Each tab has an
     alarm channel property which can be used to show an alarm indicator on
     the tab.  The indicator is driven by the alarm severity of the specified
     channel, not the value.
+
+    The active tab can be controlled via the rules system using the
+    ``Current Tab`` rule property.
 
     Parameters
     ----------
@@ -198,10 +201,18 @@ class PyDMTabWidget(QTabWidget):
         The parent widget for the Tab Widget
     """
 
+    new_properties = {"Current Tab": ["setCurrentIndex", int]}
+
     def __init__(self, parent=None):
-        super().__init__(parent)
+        QTabWidget.__init__(self, parent)
+        PyDMPrimitiveWidget.__init__(self)
         self.tb = PyDMTabBar(parent=self)
         self.setTabBar(self.tb)
+        PostParentClassInitSetup(self)
+
+    def check_enable_state(self):
+        """No-op required by ``PostParentClassInitSetup``."""
+        pass
 
     def readCurrentTabAlarmChannel(self) -> QByteArray:
         """


### PR DESCRIPTION
## Summary
- Inherit from PyDMPrimitiveWidget to gain rules system
- Expose setCurrentIndex as "Current Tab" rule property

Fixes #825