### PR TITLE
Add per-display properties to hide nav, menu, and status bars

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -15,6 +15,12 @@ from typing import Dict, Optional, Tuple
 import re
 import six
 from qtpy.QtWidgets import QApplication, QWidget
+from .utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 from .help_files import HelpWindow
 from .utilities import import_module_by_filename, is_pydm_app, macro, ACTIVE_QT_WRAPPER, QtWrapperTypes
@@ -341,6 +347,9 @@ class Display(QWidget):
         self._previous_display = None
         self._next_display = None
         self._local_style = ""
+        self._hide_nav_bar = False
+        self._hide_menu_bar = False
+        self._hide_status_bar = False
         if ui_filename or self.ui_filename():
             self.load_ui(macros=macros)
 
@@ -483,3 +492,63 @@ class Display(QWidget):
                 self._local_style = f.read()
         logger.debug("Setting stylesheet to: %s", self._local_style)
         super().setStyleSheet(self._local_style)
+
+    def readHideNavigationBar(self) -> bool:
+        """Whether the navigation bar should be hidden when this display is shown.
+
+        Returns
+        -------
+        bool
+        """
+        return self._hide_nav_bar
+
+    def setHideNavigationBar(self, value: bool) -> None:
+        """Set whether the navigation bar should be hidden.
+
+        Parameters
+        ----------
+        value : bool
+        """
+        self._hide_nav_bar = value
+
+    hideNavigationBar = Property(bool, readHideNavigationBar, setHideNavigationBar)
+
+    def readHideMenuBar(self) -> bool:
+        """Whether the menu bar should be hidden when this display is shown.
+
+        Returns
+        -------
+        bool
+        """
+        return self._hide_menu_bar
+
+    def setHideMenuBar(self, value: bool) -> None:
+        """Set whether the menu bar should be hidden.
+
+        Parameters
+        ----------
+        value : bool
+        """
+        self._hide_menu_bar = value
+
+    hideMenuBar = Property(bool, readHideMenuBar, setHideMenuBar)
+
+    def readHideStatusBar(self) -> bool:
+        """Whether the status bar should be hidden when this display is shown.
+
+        Returns
+        -------
+        bool
+        """
+        return self._hide_status_bar
+
+    def setHideStatusBar(self, value: bool) -> None:
+        """Set whether the status bar should be hidden.
+
+        Parameters
+        ----------
+        value : bool
+        """
+        self._hide_status_bar = value
+
+    hideStatusBar = Property(bool, readHideStatusBar, setHideStatusBar)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -152,13 +152,31 @@ class PyDMMainWindow(QMainWindow):
         new_widget.setVisible(True)
         self._display_widget = new_widget
         self.setCentralWidget(self._display_widget)
+        self._apply_display_bar_visibility(new_widget)
         self.enable_disable_navigation()
         self.update_window_title()
         self.add_menu_items()
-        # Resizing to the new widget's dimensions needs to be
-        # done on the event loop for some reason - you can't
-        # just do it here.
         QTimer.singleShot(0, self.resizeForNewDisplayWidget)
+
+    def _apply_display_bar_visibility(self, display):
+        """Apply per-display bar visibility preferences.
+
+        If the display defines ``hideNavigationBar``, ``hideMenuBar``, or
+        ``hideStatusBar`` properties, the corresponding bars are toggled.
+
+        Parameters
+        ----------
+        display : QWidget
+            The display widget being loaded.
+        """
+        if getattr(display, "_hide_nav_bar", False):
+            self.toggle_nav_bar(False)
+            self.ui.actionShow_Navigation_Bar.setChecked(False)
+        if getattr(display, "_hide_menu_bar", False):
+            self.ui.actionShow_Menu_Bar.activate(QAction.Trigger)
+        if getattr(display, "_hide_status_bar", False):
+            self.toggle_status_bar(False)
+            self.ui.actionShow_Status_Bar.setChecked(False)
 
     def clear_display_widget(self):
         if self._display_widget is not None:


### PR DESCRIPTION
## Summary
- Display exposes hideNavigationBar, hideMenuBar, hideStatusBar as Qt Properties
- Main window reads these when loading a display and toggles bars

Fixes #1113