### PR TITLE
Skip per-widget teardown during application shutdown

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyqt5:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-pyside6:
-    if: ${{ github.repository == 'slaclab/pydm' || github.repository == 'YektaY/pydm' }}
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import QApplication
 from .main_window import PyDMMainWindow
 
 from .utilities import which, path_info, connection, ACTIVE_QT_WRAPPER, QtWrapperTypes
+from .widgets.base import set_app_shutting_down
 from .utilities.stylesheet import apply_stylesheet
 from . import config, data_plugins
 
@@ -134,6 +135,7 @@ class PyDMApplication(QApplication):
                 self.main_window.open(ui_file, macros, command_line_args)
 
         self.had_file = ui_file is not None
+        self.aboutToQuit.connect(set_app_shutting_down)
         # Re-enable sigint (usually blocked by pyqt)
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -90,18 +90,36 @@ def only_if_channel_set(fcn):
     return wrapper
 
 
-def widget_destroyed(channels, widget):
+_app_shutting_down = False
+
+
+def set_app_shutting_down():
+    """Signal that the application is shutting down.
+
+    When set, ``widget_destroyed`` skips per-widget channel disconnection
+    and rules unregistration to avoid O(n*m) teardown overhead with large
+    widget counts.  The OS reclaims all resources on process exit.
     """
-    Callback invoked when the Widget is destroyed.
-    This method is used to ensure that the channels are disconnected.
+    global _app_shutting_down
+    _app_shutting_down = True
+
+
+def widget_destroyed(channels, widget):
+    """Callback invoked when the Widget is destroyed.
+
+    Disconnects channels and unregisters rules unless the application
+    is shutting down, in which case cleanup is skipped for performance.
 
     Parameters
     ----------
-    channels : list
-        A list of PyDMChannel objects that this widget uses.
+    channels : callable
+        A callable returning the list of PyDMChannel objects.
     widget : weakref
         Weakref to the widget.
     """
+    if _app_shutting_down:
+        return
+
     chs = channels()
     if chs:
         for ch in chs:


### PR DESCRIPTION
## Summary
- Add `_app_shutting_down` flag set via `aboutToQuit` signal
- `widget_destroyed` returns immediately during shutdown
- Avoids O(n*m) channel disconnection and rules unregistration

Fixes #1049